### PR TITLE
Improve ORM loading speed at frontpage

### DIFF
--- a/src/templates/home.html
+++ b/src/templates/home.html
@@ -69,7 +69,7 @@
             <p>please select the primary site you want</p>
             <select multiple="multiple" id="select1" name="select1">
                     <optgroup label="Sanger cell line project" id="optgroup1">
-                        {% for s in keys1 %}
+                        {% for s in primary_sites %}
                             <option value="{{ s }}">{{ s }}</option>
                         {% endfor %}
                     </optgroup>
@@ -79,20 +79,25 @@
           <div id="test"></div>
           <!-- Table -->
             <table class="table table-striped">
+                <thead>
                 <tr>
                     <th>Cell Line name</th>
                     <th>Primary site</th>
                     <th>Primary histology</th>
                     <th>dataset</th>
                 </tr>
-                {% for l in set0 %}
-                    <tr name="{{l.cell_line_id.primary_site}}" class="class1">
+                </thead>
+                <tbody>
+                {% for l in samples %}
+                    {# Add display:none to increase HTML DOM loading #}
+                    <tr name="{{l.cell_line_id.primary_site}}" class="class1" style="display:none">
                         <td>{{ l.cell_line_id.name }}</td>
                         <td>{{ l.cell_line_id.primary_site }}</td>
                         <td>{{ l.cell_line_id.primary_hist }}</td>
                         <td>Sanger project</td>
                     </tr>
                 {% endfor %}
+                </tbody>
             </table>
         </div>
         <div class="panel panel-default" name="nci_table">
@@ -102,7 +107,7 @@
             <p>please select the primary site you want</p>
             <select multiple="multiple" id="select2" name=="select2">
                     <optgroup label="nci60" id="optgroup2">
-                        <!--{% for s in keys1 %}
+                        <!--{% for s in primary_sites %}
                             <option value="{{ s }}">{{ s }}</option>
                         {% endfor %}-->
                     </optgroup>


### PR DESCRIPTION
Preload sample and its cell line at first query to reduce the number of total queries.

More about the Django ORM `select_related` and `prefetch_related` can be found at [its documentation page](https://docs.djangoproject.com/en/1.9/topics/db/optimization/#retrieve-everything-at-once-if-you-know-you-will-need-it).

除了這之外，我有稍微調整一下 code style：
- 用 dataset 的名字 query，不能保証一定是 id=1
- 把 `set0`和 `keys1` 改成 `samples` 和 `primary_sites` 他們實際意義的名字，這樣比較好懂。
- PEP8 對空白與換行的要求

關於最後一點，可能所有 code 的 code style 都要調整，但這個就有空再做吧。
