### PR TITLE
Use raw SQL query to boost cell line dataset lookup

### DIFF
--- a/src/probes/models.py
+++ b/src/probes/models.py
@@ -1,3 +1,4 @@
+import itertools
 from django.db import models
 from decimal import Decimal
 
@@ -35,15 +36,61 @@ class Sample(models.Model):
         return 'name=%s filename=%s' % (self.name, self.filename)
 
 
-        
+class CellLineQuerySet(models.QuerySet):
+
+    def annotate_dataset_name(self):
+        '''Return cell line objects with dataset names
+
+        Note:
+            Cell lines can be duplicated if found in multiple datasets
+        '''
+        return self.raw('''
+            SELECT DISTINCT
+                c.id AS id,
+                c.name AS name,
+                c.primary_site AS primary_site,
+                c.primary_hist AS primary_hist,
+                sample_extended.dset_name AS dset_name
+            FROM (
+                -- Retrieve all dataset names for each sample
+                SELECT
+                    s.cell_line_id_id AS cl_id,
+                    ds.id AS dset_id,
+                    ds.name AS dset_name
+                FROM probes_sample AS s
+                JOIN probes_dataset AS ds
+                ON s.dataset_id_id = ds.id
+            ) AS sample_extended
+            JOIN probes_cellline AS c
+            ON sample_extended.cl_id = c.id
+            ORDER BY id, dset_name
+        ''')
+
+    def collapsed(self):
+        '''Collapse cell line dataset annotation.
+
+        Note:
+            Records for cell line will be distinct, and dataset names are
+            collapsed into the attribute `dataset_names`
+        '''
+        for cell_line_id, grp in itertools.groupby(
+            self.annotate_dataset_name(), lambda cl: cl.id
+        ):
+            records = list(grp)
+            cell_line_obj = records[0]
+            cell_line_obj.dataset_names = [r.dset_name for r in records]
+            yield cell_line_obj
+
+
 #need to update with new datasets
 class CellLine(models.Model):
 
     name = models.CharField(max_length=20)
     primary_site = models.CharField(max_length=50)
     primary_hist = models.CharField(max_length=50)
-    
-    
+
+    by_datasets = CellLineQuerySet.as_manager()
+
     def __str__(self):
         return '%s of %s of %s' % (self.name, self.primary_site, self.primary_hist)
 

--- a/src/probes/views.py
+++ b/src/probes/views.py
@@ -44,19 +44,11 @@ def home(request):
 
 
 def cell_lines(request):
-    samples = Sample.objects.all().select_related('cell_line_id','dataset_id')
-    
-    #lines = Sample.objects.select_related('cell_line_id','dataset_id')
-    lines=CellLine.objects.all().distinct()
-    #dataset_name=lines.values_list('fcell_line_id__dataset_id__name')
-    
-    val_pairs = (
-                (l, l.fcell_line_id.prefetch_related('dataset_id__name').values_list('dataset_id__name',flat=True).distinct())                        
-                for l in lines
-            )
-    context['val_pairs']=val_pairs
-    return render_to_response('cell_line.html', RequestContext(request, context))
-    
+    cell_lines_w_dset = CellLine.by_datasets.collapsed()
+    return render(request, 'cell_line.html', {
+        'cell_lines_with_datasets': cell_lines_w_dset
+    })
+
 
 def data(request):
     SANGER=[]

--- a/src/templates/cell_line.html
+++ b/src/templates/cell_line.html
@@ -26,16 +26,12 @@
             </thead>
             
             <tbody>
-                {% for l,data in val_pairs %}
+                {% for cl in cell_lines_with_datasets %}
                     <tr>
-                        <td>{{ l.name }}</td>
-                        <td>{{ l.primary_site }}</td>
-                        <td>{{ l.primary_hist }}</td>
-                        <td>
-                        {% for c in data %}
-                            {{ c }}<br />
-                        {% endfor %}
-                        </td>
+                        <td>{{ cl.name }}</td>
+                        <td>{{ cl.primary_site }}</td>
+                        <td>{{ cl.primary_hist }}</td>
+                        <td>{{ cl.dataset_names|join:"<br>" }}</td>
                     </tr>
                 {% endfor %}
             </tbody>


### PR DESCRIPTION
For alternative solution using SQL `GROUP BY`, refer to discussion in #3.

Here we group the duplicated cell line records (with different dataset names) in Python using [`itertools.groupby`](https://docs.python.org/3.5/library/itertools.html#itertools.groupby). An important detail is that the SQL query requires to be **already sorted by cell line**, otherwise the groupby will have bogus result.

The complicated implementation of this SQL query is collected as a `CellLine`'s [`QuerySet`](https://docs.djangoproject.com/en/1.9/ref/models/querysets/#django.db.models.query.QuerySet) via `CellLine.by_datasets.xxx`. It resembles the usage of the ordinal `CellLine.objects.xxx`.

After this change the rendering time of /cell_line reduces from 10s to roughly 0.2s (first load 0.5s). 
